### PR TITLE
fix: mute description & points hypertext

### DIFF
--- a/en/bot.json
+++ b/en/bot.json
@@ -14,7 +14,7 @@
 	"unban_description": "Unbans a member.",
 	"kick_description": "Kicks a member.",
 	"vkick_description": "Kicks a member from a voice channel",
-	"mute_description": "Mute a member from text channels so they cannot type.",
+	"mute_description": "Mute a member from text/voice channels so they cannot type.",
 	"vmute_description": "Mute a member from voice channels so they cannot speak.",
 	"unvmute_description": "Unmutes a member from voice channels.",
 	"move_description": "Moves a member to another voice channel.",

--- a/en/bot.json
+++ b/en/bot.json
@@ -14,7 +14,7 @@
 	"unban_description": "Unbans a member.",
 	"kick_description": "Kicks a member.",
 	"vkick_description": "Kicks a member from a voice channel",
-	"mute_description": "Mute a member from text/voice channels so they cannot type.",
+	"mute_description": "Mute a member from text/voice channels so they cannot type/speak.",
 	"vmute_description": "Mute a member from voice channels so they cannot speak.",
 	"unvmute_description": "Unmutes a member from voice channels.",
 	"move_description": "Moves a member to another voice channel.",

--- a/examples.json
+++ b/examples.json
@@ -49,7 +49,7 @@
         "usage_deletebackup": "{0} [Backup Code]",
         "usage_short": "{0} [link]",
         "usage_roll": "{0} (number)",
-        "usage_points": "`{0}` - see all points\n`{0} [user] 1` - set the points of a user\n`{0} [user] +1` - increase the points of a user\n`{0} [user] -1` - decrease the points of a user\n`{0} [user] 0` -  reset the points of a user\n`{0} reset` - resets all points\n{0} [role name] - filters the points by a role",
+        "usage_points": "`{0}` - see all points\n`{0} [user] 1` - set the points of a user\n`{0} [user] +1` - increase the points of a user\n`{0} [user] -1` - decrease the points of a user\n`{0} [user] 0` -  reset the points of a user\n`{0} reset` - resets all points\n`{0} [role name]` - filters the points by a role",
         "usage_removewarn": "{0} [warnID]\n{0} [user]\n{0} all",
         "usage_setlang": "{0} [Language Code]",
         "usage_invite": "{0}",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

> In slash commands now you can specify mute type either be a text mute or voice mute.

> Fix points usage text.

![mute_description](https://user-images.githubusercontent.com/53066189/142004666-03f30395-7350-41c3-a986-6945a5bc7064.png)
![points_usage](https://user-images.githubusercontent.com/53066189/142149606-87e82ae1-c5c7-4f96-8f73-88f49769f156.png)