### PR TITLE
ci: Add auto labeler & assign reviewers

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+'Bot Strings':
+  - en/bot.json
+
+'Website Strings':
+  - en/website.json
+
+'Example & Usage':
+  - examples.json

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,6 @@
+addReviewers: true
+reviewers:
+  - Dramex
+  - FnrDev
+
+numberOfReviewers: 0

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -6,5 +6,5 @@ on:
         runs-on: ubuntu-latest
         steps:
         - name: Automatically assign reviewers
-          if: ${{ github.event.action == 'opened' }}
+          if: github.event.action == 'opened'
           uses: kentaro-m/auto-assign-action@v1.1.2

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,10 +1,11 @@
-name: 'Add reviewers'
+name: 'PR Triage'
 on:
   pull_request_target:
-    jobs:
-      triage:
-        runs-on: ubuntu-latest
-        steps:
-        - name: Automatically assign reviewers
-          if: github.event.action == 'opened'
-          uses: kentaro-m/auto-assign-action@v1.1.2
+jobs:
+  pr-triage:
+    name: PR Triage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automatically assign reviewers
+        if: github.event.action == 'opened'
+        uses: kentaro-m/auto-assign-action@v1.2.1

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,11 +1,10 @@
-name: "Pull Request Labeler"
+name: 'Add reviewers'
 on:
-- pull_request_target
-
-jobs:
-  triage:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/labeler@v3
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+  pull_request_target:
+    jobs:
+      triage:
+        runs-on: ubuntu-latest
+        steps:
+        - name: Automatically assign reviewers
+          if: ${{ github.event.action == 'opened' }}
+          uses: kentaro-m/auto-assign-action@v1.1.2

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,0 +1,10 @@
+name: 'Assign Reviewers'
+on:
+  pull_request_target:
+    jobs:
+      triage:
+        runs-on: ubuntu-latest
+        steps:
+        - name: Automatically assign reviewers
+        if: ${{ github.event.action == 'opened' }}
+        uses: kentaro-m/auto-assign-action@v1.1.2

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,10 +1,11 @@
-name: 'Assign Reviewers'
+name: "Pull Request Labeler"
 on:
-  pull_request_target:
-    jobs:
-      triage:
-        runs-on: ubuntu-latest
-        steps:
-        - name: Automatically assign reviewers
-        if: ${{ github.event.action == 'opened' }}
-        uses: kentaro-m/auto-assign-action@v1.1.2
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,11 +1,11 @@
 name: "Pull Request Labeler"
 on:
-  - pull_request_target
+- pull_request_target
 
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v3
-    with:
-      repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+    with:
+      repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/en/bot.json
+++ b/en/bot.json
@@ -482,5 +482,5 @@
 	"vip_whitelist_description": "Whitelist a user to allow access to the ProBot panel.",
 	"vip_whitelist_user_description": "The user to add / remove from ProBot panel.",
 	"vip_no_perms": ":x: You need administrator permission to use vip commands.",
-  	"button_someone_else": ":x: This button belongs to someone else."
+  "button_someone_else": ":x: This button belongs to someone else."
 }

--- a/en/bot.json
+++ b/en/bot.json
@@ -467,7 +467,6 @@
 	"lock_already_locked": "**:x: Channel is already locked {0}.**",
 	"reset_type_description": "Select the type of the reset",
 	"reset_user_description": "The user to reset stats for.",
-  "button_someone_else": ":x: This button belongs to someone else.",
 	"vip_choose_placeholder": "Select a status type.",
 	"vip_username_description": "Change the name of your premium bot.",
 	"vip_username_name_description": "The name to set in your premium bot.",
@@ -483,5 +482,5 @@
 	"vip_whitelist_description": "Whitelist a user to allow access to the ProBot panel.",
 	"vip_whitelist_user_description": "The user to add / remove from ProBot panel.",
 	"vip_no_perms": ":x: You need administrator permission to use vip commands.",
-  "button_someone_else": ":x: This button belongs to someone else."
+  	"button_someone_else": ":x: This button belongs to someone else."
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
in this PR I've added 2 workflows to assign reviewers for every opened pull request and an auto labeler for every edited file so it can be easily managed by filtering them in GitHub.

**In this PR:**

<!--
Please move lines that apply to you out of the comment:
- Strings were edited (text changed while the key stayed the same)
- Strings were added/removed (new/deleted string keys)
- Updated language name or flag
-->