### PR TITLE
new rr strings

### DIFF
--- a/en/bot.json
+++ b/en/bot.json
@@ -514,5 +514,7 @@
 	"rr_role_remove": ":x: Removed **{0}**",
 	"rr_role_no_change": ":x: No roles have been changed.",
 	"rr_no_role_button": ":x: There are no roles linked to this button.",
-	"rr_admin_role": ":x: Error in changing roles, Please make sure that the selected role has no administrative permissions."
+	"rr_admin_role": ":x: Error in changing roles, Please make sure that the selected role has no administrative permissions.",
+        "rr_already_give": ":x: Error in changing roles, you already have that role/roles.",
+        "rr_already_take": ":x: Error in changing roles, you already don't have that role/roles to remove."
 }

--- a/en/bot.json
+++ b/en/bot.json
@@ -515,6 +515,6 @@
 	"rr_role_no_change": ":x: No roles have been changed.",
 	"rr_no_role_button": ":x: There are no roles linked to this button.",
 	"rr_admin_role": ":x: Error in changing roles, Please make sure that the selected role has no administrative permissions.",
-        "rr_already_give": ":x: Error in changing roles, you already have that role/roles.",
+        "rr_already_give": ":x: Error in changing roles, you already have that role",
         "rr_already_take": ":x: Error in changing roles, you already don't have that role/roles to remove."
 }

--- a/en/bot.json
+++ b/en/bot.json
@@ -516,5 +516,5 @@
 	"rr_no_role_button": ":x: There are no roles linked to this button.",
 	"rr_admin_role": ":x: Error in changing roles, Please make sure that the selected role has no administrative permissions.",
         "rr_already_give": ":x: Error in changing roles, you already have that role",
-        "rr_already_take": ":x: Error in changing roles, you already don't have that role/roles to remove."
+        "rr_already_take": ":x: Error in changing roles, you already don't have that role to remove."
 }


### PR DESCRIPTION
Context: If you select the reaction type to (give) and you already have that role, it will respond with the "rr_already_give" string.

Same thing for the ( take ) type, if you don't have that it'll respond with the "rr_already_take" string. 