### PR TITLE
Color string

### DIFF
--- a/en/bot.json
+++ b/en/bot.json
@@ -518,5 +518,6 @@
 	"rr_admin_role": ":x: Please ensure that the selected role has no administrative permissions, as well as relocate my role above the selected roles.",
         "rr_already_give": ":x: Error with changing **{0}** role, you already have that role.",
         "rr_already_take": ":x: Error with changing **{0}** role, you already don't have that role to remove.",
-        "point_list_page_description": "Choose a points page number"
+        "point_list_page_description": "Choose a points page number",
+        "color_relocate": ":rolling_eyes: - Please move my role above the selected color role.."
 }

--- a/en/bot.json
+++ b/en/bot.json
@@ -519,5 +519,5 @@
         "rr_already_give": ":x: Error with changing **{0}** role, you already have that role.",
         "rr_already_take": ":x: Error with changing **{0}** role, you already don't have that role to remove.",
         "point_list_page_description": "Choose a points page number",
-        "color_relocate": ":rolling_eyes: - Please move my role above the selected color role.."
+        "color_relocate": ":rolling_eyes: - Please move my role above the selected color role."
 }


### PR DESCRIPTION
A new string If the bots role was under the selected color role. Instead of responding with ":rolling eyes: - Color role should not have administrative permissions,"